### PR TITLE
Restrict the version to smaller than 0.7.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 745d66716531f9063127274b40503fbc21f931f78b7b03e79e5523d50078bc17
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -23,7 +23,7 @@ requirements:
     - six >=1.9.0
     - numpy >=1.9.1
     - scipy >=0.14
-    - pygpu >=0.6.5
+    - pygpu >=0.6.5,<0.7
 
 test:
   requires:


### PR DESCRIPTION
We are preparing for a 0.7 release of libgpuarray, but Theano 0.9 will not work with it due to a number of API differences.

This updates the version requirement to note this conflict.