### PR TITLE
add setuptools as runtime dep

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "0.9.0" %}
+{% set build = 3 %}
 
 package:
   name: theano
@@ -10,7 +11,7 @@ source:
   sha256: 745d66716531f9063127274b40503fbc21f931f78b7b03e79e5523d50078bc17
 
 build:
-  number: 2
+  number: {{ build }}
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
 
   run:
     - python
+    - setuptools
     - six >=1.9.0
     - numpy >=1.9.1
     - scipy >=0.14


### PR DESCRIPTION
[`theano.gpuarray.linalg`](https://github.com/Theano/Theano/blob/f8926b53d73422e6648617e1c50872b83b069a48/theano/gpuarray/linalg.py) uses `pkg_resources.DistributionNotFound`, which is in `setuptools`. So users can get confusing error messages if setuptools isn't installed: https://github.com/conda-forge/staged-recipes/pull/3921. This adds setuptools as a runtime dependency to avoid that.