### PR TITLE
Release 1.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 {% set build = 0 %}
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: Theano-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/T/Theano/Theano-{{ version }}.tar.gz
-  sha256: 7bc82e4fcaac023cac23c390b30d5df81bc09d33568812df75b0bd2b86d2fa8f
+  sha256: 88d8aba1fe2b6b75eacf455d01bc7e31e838c5a0fb8c13dde2d9472495ff4662
 
 build:
   number: {{ build }}


### PR DESCRIPTION
```
Theano 1.0.1 (6th of December, 2017)
====================================

This is a maintenance release of Theano, version ``1.0.1``, with no new features, but some important bug fixes.

We recommend that everybody update to this version.

Highlights (since 1.0.0):

 - Fixed compilation and improved float16 support for topK on GPU

   - **NB**: topK support on GPU is experimental and may not work for large input sizes on certain GPUs

 - Fixed cuDNN reductions when axes to reduce have size ``1``
 - Attempted to prevent re-initialization of the GPU in a child process
 - Fixed support for temporary paths with spaces in Theano initialization
 - Spell check pass on the documentation

A total of 6 people contributed to this release since ``1.0.0``:

 - Frederic Bastien
 - Steven Bocco
 - Arnaud Bergeron
 - Sam Johnson
 - Edward Betts
 - Simon Lefrancois
```